### PR TITLE
Build a custom queue object

### DIFF
--- a/src/algorithms/queueObject.js
+++ b/src/algorithms/queueObject.js
@@ -1,0 +1,24 @@
+export default class Queue {
+  constructor(...args) {
+    this.length = args.length;
+    for(let i = 1; i <= args.length; i++) {
+      this[i] = args[i - 1];
+    }
+  }
+  push(item) {
+    this.length += 1;
+    this[this.length] = item;
+  }
+  pop() {
+    if (!this.length) {
+      throw new Error('queue is empty');
+    }
+    const firstItem = this[1];
+    for(let i = 1; i < this.length; i++) {
+      Object.defineProperty(this, i, {value: this[i +1]});
+    }
+    delete this[this.length];
+    this.length -= 1;
+    return firstItem;
+  }
+}

--- a/src/algorithms/queueObject.test.js
+++ b/src/algorithms/queueObject.test.js
@@ -1,0 +1,36 @@
+import Queue from './queueObject'
+describe('This is a pseudo TDD build of a queue object', () => {
+  test('queue can be instantiated', () => {
+    expect(new Queue).toBeInstanceOf(Queue);
+  });
+  test('queues instantiated withh 3 items will have a length of 3', () => {
+    const queue = new Queue(1, 2, 3);
+    expect(queue).toHaveProperty('length', 3);
+  });
+  test('pushing an item to the queue lengthens the queue by 1', () => {
+    const queue = new Queue;
+    queue.push(1);
+    expect(queue).toHaveProperty('length', 1)
+  });
+  test('popping an item from the queue decreases the length of the queue by 1', () => {
+    const queue = new Queue(1, 2, 3);
+    queue.pop();
+    expect(queue).toHaveProperty('length', 2);
+  });
+  test('popping an empty queue will throw an error', () => {
+    const queue = new Queue;
+    expect(() => queue.pop()).toThrow('queue is empty');
+  });
+  test('popping a queue gives the first item in the queue', () => {
+    const queue = new Queue(1, 2, 3);
+    expect(queue.pop()).toBe(1);
+  });
+  test('pushing an item to the queue puts that item at the back of the queue', () => {
+    const queue = new Queue(1, 2, 3,);
+    queue.push(4);
+    queue.pop();
+    queue.pop();
+    queue.pop();
+    expect(queue.pop()).toBe(4);
+  });
+});

--- a/src/algorithms/stackObject.test.js
+++ b/src/algorithms/stackObject.test.js
@@ -43,4 +43,11 @@ describe('methods', () => {
     const stack = new Stack();
     expect(() => stack.size = 1).toThrow('*softly* ...don\'t');
   });
+  test('stacks work like stacks', () => {
+    const stack = new Stack();
+    stack.push(1);
+    stack.push(2);
+    stack.push(3);
+    expect(stack.pop()).toBe(3);
+  })
 });


### PR DESCRIPTION
object has push() and pop() methods
object throws an error when pop() is called on an empty queue
object uses Object.defineProperty to reassign key:value pairs after pop() is called